### PR TITLE
BaseAPIView for Views to create a CRUD

### DIFF
--- a/src/application/authentication/responses/user_vm.py
+++ b/src/application/authentication/responses/user_vm.py
@@ -5,6 +5,6 @@ from src.domain.value_objects import UserId
 
 @dataclass
 class UserVm:
-    user_id: UserId
+    id: UserId
     username: str
     email: str

--- a/src/application/currency/responses/currency_detail_vm.py
+++ b/src/application/currency/responses/currency_detail_vm.py
@@ -5,7 +5,7 @@ from src.domain.value_objects import CurrencyId
 
 @dataclass
 class CurrencyDetailVm:
-    currency_id: CurrencyId
+    id: CurrencyId
     code: str
     name: str
     symbol: str

--- a/src/application/currency/responses/currency_vm.py
+++ b/src/application/currency/responses/currency_vm.py
@@ -5,7 +5,7 @@ from src.domain.value_objects import CurrencyId
 
 @dataclass
 class CurrencyVm:
-    currency_id: CurrencyId
+    id: CurrencyId
     # code: str
     name: str
     # symbol: str

--- a/src/domain/entities/account.py
+++ b/src/domain/entities/account.py
@@ -8,7 +8,7 @@ from src.domain.value_objects import UserId
 
 @dataclass
 class User:
-    user_id: UserId
+    id: UserId
     email: str
     username: str
     password: str

--- a/src/domain/entities/currency.py
+++ b/src/domain/entities/currency.py
@@ -5,7 +5,7 @@ from src.domain.value_objects import CurrencyId
 
 @dataclass
 class Currency:
-    currency_id: CurrencyId
+    id: CurrencyId
     code: str
     name: str
     symbol: str

--- a/src/infrastructure/providers/token_provider.py
+++ b/src/infrastructure/providers/token_provider.py
@@ -11,7 +11,6 @@ from src.infrastructure.models import User as UserModel
 
 
 class TokenProvider(TokenProviderInterface):
-
     def get_token_output(self, refresh: RefreshToken) -> dict:
         return {
             "access_token": str(refresh.access_token),
@@ -19,7 +18,7 @@ class TokenProvider(TokenProviderInterface):
         }
 
     def get_token(self, user: User) -> dict:
-        user_object = UserModel.objects.get(id=user.user_id)
+        user_object = UserModel.objects.get(id=user.id)
         refresh = RefreshToken.for_user(user_object)
         output = self.get_token_output(refresh)
         return output

--- a/src/infrastructure/repositories/account_repository.py
+++ b/src/infrastructure/repositories/account_repository.py
@@ -17,7 +17,7 @@ class UserRepository(AbstractRepository[UserModel, UserId], UserRepositoryInterf
 
     def _decode_model(self, instance: UserModel) -> User:
         return User(
-            user_id=instance.pk,
+            id=instance.pk,
             username=instance.username,
             email=instance.email,
             password=instance.password,

--- a/src/infrastructure/repositories/currency_repository.py
+++ b/src/infrastructure/repositories/currency_repository.py
@@ -14,7 +14,7 @@ class CurrencyRepository(
 
     def _decode_model(self, instance: CurrencyModel) -> Currency:
         return Currency(
-            currency_id=instance.pk,
+            id=instance.pk,
             code=instance.code,
             name=instance.name,
             symbol=instance.symbol,

--- a/src/infrastructure/services/auth_service.py
+++ b/src/infrastructure/services/auth_service.py
@@ -8,7 +8,6 @@ from django.contrib.auth import authenticate
 
 
 class AuthService(AuthServiceInterface):
-
     def authenticate(self, username: str, password: str) -> Optional[User]:
         user = authenticate(username=username, password=password)
         if user is not None:

--- a/src/presentation/rest_api/apps/common/extend_schema_meta.py
+++ b/src/presentation/rest_api/apps/common/extend_schema_meta.py
@@ -1,0 +1,154 @@
+from http import HTTPMethod, HTTPStatus
+from typing import Any
+
+from drf_spectacular.utils import OpenApiParameter, extend_schema
+
+from rest_framework.request import Request
+from src.presentation.rest_api.apps.common.serializers import NotFoundResponseSerializer
+
+
+class ExtendSchemaMeta(type):
+    def __new__(mcs, name, bases, attrs):
+        cls = super().__new__(mcs, name, bases, attrs)
+
+        list_serializer = getattr(cls, "list_serializer", None)
+        detail_serializer = getattr(cls, "detail_serializer", None)
+        create_serializer = getattr(cls, "create_serializer", None)
+        update_serializer = getattr(cls, "update_serializer", None)
+        pk_type = getattr(cls, "pk_type", int)
+
+        cls = mcs.decorate_list(cls, list_serializer)
+        cls = mcs.decorate_retrieve(cls, detail_serializer, pk_type)
+        cls = mcs.decorate_create(cls, create_serializer, detail_serializer)
+        cls = mcs.decorate_partial_update(
+            cls, update_serializer, detail_serializer, pk_type
+        )
+        cls = mcs.decorate_destroy(cls, pk_type)
+
+        return cls
+
+    @staticmethod
+    def decorate_list(cls, list_serializer):
+        if hasattr(cls, "list") and list_serializer:
+            original_list = cls.list
+
+            @extend_schema(
+                methods=[HTTPMethod.GET],
+                parameters=[
+                    OpenApiParameter(
+                        name="skip",
+                        type=int,
+                        location=OpenApiParameter.QUERY,
+                        description="Number of items to skip.",
+                    ),
+                    OpenApiParameter(
+                        name="limit",
+                        type=int,
+                        location=OpenApiParameter.QUERY,
+                        description="Maximum number of items to retrieve.",
+                    ),
+                ],
+                responses={HTTPStatus.OK: list_serializer},
+            )
+            def list_decorated(self, request: Request, *args, **kwargs):
+                return original_list(self, request, *args, **kwargs)
+
+            cls.list = list_decorated
+        return cls
+
+    @staticmethod
+    def decorate_retrieve(cls, detail_serializer, pk_type):
+        if hasattr(cls, "retrieve") and detail_serializer:
+            original_retrieve = cls.retrieve
+
+            @extend_schema(
+                methods=[HTTPMethod.GET],
+                parameters=[
+                    OpenApiParameter(
+                        name="id",
+                        type=pk_type,
+                        location=OpenApiParameter.PATH,
+                        description="Item ID",
+                    ),
+                ],
+                responses={
+                    HTTPStatus.OK: detail_serializer,
+                    HTTPStatus.NOT_FOUND: NotFoundResponseSerializer,
+                },
+            )
+            def retrieve_decorated(self, request: Request, pk: Any, *args, **kwargs):
+                return original_retrieve(self, request, pk, *args, **kwargs)
+
+            cls.retrieve = retrieve_decorated
+        return cls
+
+    @staticmethod
+    def decorate_create(cls, create_serializer, detail_serializer):
+        if hasattr(cls, "create") and create_serializer and detail_serializer:
+            original_create = cls.create
+
+            @extend_schema(
+                request=create_serializer,
+                responses={HTTPStatus.CREATED: detail_serializer},
+                methods=[HTTPMethod.POST],
+            )
+            def create_decorated(self, request: Request, *args, **kwargs):
+                return original_create(self, request, *args, **kwargs)
+
+            cls.create = create_decorated
+        return cls
+
+    @staticmethod
+    def decorate_partial_update(cls, update_serializer, detail_serializer, pk_type):
+        if hasattr(cls, "partial_update") and update_serializer and detail_serializer:
+            original_partial_update = cls.partial_update
+
+            @extend_schema(
+                request=update_serializer,
+                responses={
+                    HTTPStatus.OK: detail_serializer,
+                    HTTPStatus.NOT_FOUND: NotFoundResponseSerializer,
+                },
+                methods=[HTTPMethod.PATCH],
+                parameters=[
+                    OpenApiParameter(
+                        name="id",
+                        type=pk_type,
+                        location=OpenApiParameter.PATH,
+                        description="Item ID",
+                    ),
+                ],
+            )
+            def partial_update_decorated(
+                self, request: Request, pk: Any, *args, **kwargs
+            ):
+                return original_partial_update(self, request, pk, *args, **kwargs)
+
+            cls.partial_update = partial_update_decorated
+        return cls
+
+    @staticmethod
+    def decorate_destroy(cls, pk_type):
+        if hasattr(cls, "destroy"):
+            original_destroy = cls.destroy
+
+            @extend_schema(
+                methods=[HTTPMethod.DELETE],
+                parameters=[
+                    OpenApiParameter(
+                        name="id",
+                        type=pk_type,
+                        location=OpenApiParameter.PATH,
+                        description="Item ID",
+                    ),
+                ],
+                responses={
+                    HTTPStatus.NO_CONTENT: None,
+                    HTTPStatus.NOT_FOUND: NotFoundResponseSerializer,
+                },
+            )
+            def destroy_decorated(self, request: Request, pk: Any, *args, **kwargs):
+                return original_destroy(self, request, pk, *args, **kwargs)
+
+            cls.destroy = destroy_decorated
+        return cls

--- a/src/presentation/rest_api/apps/common/views.py
+++ b/src/presentation/rest_api/apps/common/views.py
@@ -1,0 +1,109 @@
+from typing import Type
+
+from automapper import Mapper
+from mediatr import Mediator
+
+from rest_framework import status
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.viewsets import ViewSet
+from src.presentation.rest_api.apps.common.extend_schema_meta import ExtendSchemaMeta
+from src.presentation.rest_api.config.containers import container
+
+
+class BaseAPIView[
+    ListSerializerType,
+    DetailSerializerType,
+    CreateSerializerType,
+    UpdateSerializerType,
+    ListQueryType,
+    DetailQueryType,
+    CreateCommandType,
+    UpdateCommandType,
+    RemoveCommandType,
+    PKType,
+](ViewSet, metaclass=ExtendSchemaMeta):
+    authentication_classes = ()
+
+    list_serializer: Type[ListSerializerType]
+    detail_serializer: Type[DetailSerializerType]
+    create_serializer: Type[CreateSerializerType]
+    update_serializer: Type[UpdateSerializerType]
+    list_query: Type[ListQueryType]
+    detail_query: Type[DetailQueryType]
+    create_command: Type[CreateCommandType]
+    update_command: Type[UpdateCommandType]
+    remove_command: Type[RemoveCommandType]
+
+    pk_type: Type[PKType]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.__mediator: Mediator = container.resolve(Mediator)
+        self.__mapper: Mapper = container.resolve(Mapper)
+
+    def list(self, request: Request) -> Response:
+        parameters = {
+            "skip": int(request.query_params.get("skip", 0)),
+            "limit": int(request.query_params.get("limit", 100)),
+        }
+
+        query = self.list_query(**parameters)
+        result = self.__mediator.send(query)
+
+        return Response(
+            data=self.list_serializer(result, many=True).data,
+            status=status.HTTP_200_OK,
+        )
+
+    def retrieve(self, request: Request, pk: PKType) -> Response:
+        query = self.detail_query(id=pk)
+        result = self.__mediator.send(query)
+
+        if not result:
+            return Response(
+                data={"detail": "Not found."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        return Response(
+            data=self.detail_serializer(result).data,
+            status=status.HTTP_200_OK,
+        )
+
+    def create(self, request: Request) -> Response:
+        serializer = self.create_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        command = self.__mapper.to(self.create_command).map(serializer.validated_data)
+        result = self.__mediator.send(command)
+
+        return Response(
+            data=self.detail_serializer(result).data,
+            status=status.HTTP_201_CREATED,
+        )
+
+    def partial_update(self, request: Request, pk: PKType) -> Response:
+        serializer = self.update_serializer(data=request.data, partial=True)
+        serializer.is_valid(raise_exception=True)
+
+        command = self.__mapper.to(self.update_command).map(
+            serializer.validated_data, fields_mapping={"id": pk}
+        )
+        result = self.__mediator.send(command)
+
+        if not result:
+            return Response(
+                data={"detail": "Not found."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        return Response(
+            data=self.detail_serializer(result).data,
+            status=status.HTTP_200_OK,
+        )
+
+    def destroy(self, request: Request, pk: PKType) -> Response:
+        command = self.remove_command(id=pk)
+        result = self.__mediator.send(command)
+        return Response(data=result, status=status.HTTP_204_NO_CONTENT)

--- a/src/presentation/rest_api/apps/currency/views.py
+++ b/src/presentation/rest_api/apps/currency/views.py
@@ -1,14 +1,5 @@
-from http import HTTPMethod, HTTPStatus
-from typing import Optional
-
-from automapper import Mapper
-from drf_spectacular.utils import OpenApiParameter, extend_schema
-from mediatr import Mediator
-
-from rest_framework import status
-from rest_framework.request import Request
-from rest_framework.response import Response
-from rest_framework.viewsets import ViewSet
+from src.presentation.rest_api.apps.common.views import BaseAPIView
+from src.domain.value_objects import CurrencyId
 from src.application.currency.commands.add_currency.add_currency_command import (
     AddCurrencyCommand,
 )
@@ -24,117 +15,36 @@ from src.application.currency.queries.get_currencies_list.get_currencies_list_qu
 from src.application.currency.queries.get_currency_detail.get_currency_detail_query import (
     GetCurrencyDetailQuery,
 )
-from src.domain.value_objects import CurrencyId
-from src.presentation.rest_api.apps.common.serializers import NotFoundResponseSerializer
 from src.presentation.rest_api.apps.currency.serializers import (
     CreateCurrencyRequestSerializer,
     DetailCurrencyResponseSerializer,
     ListCurrencyResponseSerializer,
     UpdateCurrencyRequestSerializer,
 )
-from src.presentation.rest_api.config.containers import container
 
 
-class CurrencyAPIView(ViewSet):
+class CurrencyAPIView(
+    BaseAPIView[
+        ListCurrencyResponseSerializer,
+        DetailCurrencyResponseSerializer,
+        CreateCurrencyRequestSerializer,
+        UpdateCurrencyRequestSerializer,
+        GetCurrenciesListQuery,
+        GetCurrencyDetailQuery,
+        AddCurrencyCommand,
+        EditCurrencyCommand,
+        RemoveCurrencyCommand,
+        CurrencyId,
+    ]
+):
     authentication_classes = ()
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.__mediator = container.resolve(Mediator)
-        self.__mapper = container.resolve(Mapper)
-
-    @extend_schema(
-        methods=[HTTPMethod.GET],
-        parameters=[
-            OpenApiParameter(
-                "skip",
-                int,
-                OpenApiParameter.QUERY,
-                description="Number of items to skip.",
-            ),
-            OpenApiParameter(
-                "limit",
-                int,
-                OpenApiParameter.QUERY,
-                description="Maximum number of items to retrieve.",
-            ),
-        ],
-        responses=ListCurrencyResponseSerializer,
-    )
-    def list(self, request: Request) -> Response:
-        parameters = {
-            "skip": int(request.query_params.get("skip", 0)),
-            "limit": int(request.query_params.get("limit", 100)),
-        }
-
-        query = GetCurrenciesListQuery(**parameters)
-        result = self.__mediator.send(query)
-
-        return Response(
-            data=ListCurrencyResponseSerializer(result, many=True).data,
-            status=status.HTTP_200_OK,
-        )
-
-    @extend_schema(
-        methods=[HTTPMethod.GET],
-        parameters=[OpenApiParameter("id", CurrencyId, OpenApiParameter.PATH)],
-        responses={
-            HTTPStatus.OK: DetailCurrencyResponseSerializer,
-            HTTPStatus.NOT_FOUND: NotFoundResponseSerializer,
-        },
-    )
-    def retrieve(self, request: Request, pk: Optional[CurrencyId]) -> Response:
-        query = GetCurrencyDetailQuery(id=pk)
-        result = self.__mediator.send(query)
-
-        return Response(
-            data=DetailCurrencyResponseSerializer(result).data,
-            status=status.HTTP_200_OK,
-        )
-
-    @extend_schema(
-        request=CreateCurrencyRequestSerializer,
-        responses={HTTPStatus.CREATED: DetailCurrencyResponseSerializer},
-        methods=[HTTPMethod.POST],
-    )
-    def create(self, request: Request) -> Response:
-        command = self.__mapper.to(AddCurrencyCommand).map(request.data)
-        result = self.__mediator.send(command)
-
-        return Response(
-            data=DetailCurrencyResponseSerializer(result).data,
-            status=status.HTTP_201_CREATED,
-        )
-
-    @extend_schema(
-        request=UpdateCurrencyRequestSerializer,
-        responses={
-            HTTPStatus.OK: DetailCurrencyResponseSerializer,
-            HTTPStatus.NOT_FOUND: NotFoundResponseSerializer,
-        },
-        methods=[HTTPMethod.PATCH],
-        parameters=[OpenApiParameter("id", CurrencyId, OpenApiParameter.PATH)],
-    )
-    def partial_update(self, request: Request, pk: CurrencyId) -> Response:
-        command = self.__mapper.to(EditCurrencyCommand).map(
-            request.data, fields_mapping={"id": pk}
-        )
-        result = self.__mediator.send(command)
-
-        return Response(
-            data=DetailCurrencyResponseSerializer(result).data,
-            status=status.HTTP_200_OK,
-        )
-
-    @extend_schema(
-        methods=[HTTPMethod.DELETE],
-        parameters=[OpenApiParameter("id", CurrencyId, OpenApiParameter.PATH)],
-        responses={
-            HTTPStatus.NO_CONTENT: None,
-            HTTPStatus.NOT_FOUND: NotFoundResponseSerializer,
-        },
-    )
-    def destroy(self, request: Request, pk: CurrencyId) -> Response:
-        command = RemoveCurrencyCommand(id=pk)
-        result = self.__mediator.send(command)
-        return Response(data=result, status=status.HTTP_204_NO_CONTENT)
+    list_serializer = ListCurrencyResponseSerializer
+    detail_serializer = DetailCurrencyResponseSerializer
+    create_serializer = CreateCurrencyRequestSerializer
+    update_serializer = UpdateCurrencyRequestSerializer
+    list_query = GetCurrenciesListQuery
+    detail_query = GetCurrencyDetailQuery
+    create_command = AddCurrencyCommand
+    update_command = EditCurrencyCommand
+    remove_command = RemoveCurrencyCommand
+    pk_type = CurrencyId

--- a/tests/domain/entities/test_currency.py
+++ b/tests/domain/entities/test_currency.py
@@ -1,12 +1,12 @@
 from src.domain.entities.currency import Currency
 
-data = {"currency_id": 1, "code": "USD", "name": "US Dollar", "symbol": "$"}
+data = {"id": 1, "code": "USD", "name": "US Dollar", "symbol": "$"}
 
 
 def test_currency_creation():
     currency = Currency(**data)
 
-    assert currency.currency_id == data.get("currency_id")
+    assert currency.id == data.get("id")
     assert currency.code == data.get("code")
     assert currency.name == data.get("name")
     assert currency.symbol == data.get("symbol")
@@ -15,7 +15,7 @@ def test_currency_creation():
 def test_currency_from_dict():
     currency = Currency.from_dict(data=data)
 
-    assert currency.currency_id == data.get("currency_id")
+    assert currency.id == data.get("id")
     assert currency.code == data.get("code")
     assert currency.name == data.get("name")
     assert currency.symbol == data.get("symbol")


### PR DESCRIPTION
- **Added `BaseAPIView`:** Introduced a generic base view class to standardize CRUD operations, simplifying the creation of new API endpoints with minimal boilerplate code.

- **Implemented `ExtendSchemaMeta` Metaclass:** Developed a metaclass that automatically applies `@extend_schema` decorators to CRUD methods (`list`, `retrieve`, `create`, `partial_update`, `destroy`), enhancing OpenAPI documentation generation.

- **Dynamic Primary Key Typing:** Enabled dynamic typing for primary keys (`pk_type`), ensuring accurate type annotations and improved API documentation based on the specified `pk_type`.

- **Refactored Existing Views:** Updated existing API views (e.g., `CurrencyAPIView`) to inherit from `BaseAPIView`, reducing code duplication and improving maintainability.

- **Updated Linter Configuration:** Modified `pyproject.toml` to move deprecated `ruff` linter settings to the new `[tool.ruff.lint]` section, ensuring compliance with the latest linter configuration standards.

---

**Example Usage:**

Now, creating a new CRUD API view is straightforward. Here's how you can define `CurrencyAPIView` using the newly added `BaseAPIView`:

```python
from src.application.currency.commands.add_currency.add_currency_command import AddCurrencyCommand
from src.application.currency.commands.edit_currency.edit_currency_command import EditCurrencyCommand
from src.application.currency.commands.remove_currency.remove_currency_command import RemoveCurrencyCommand
from src.application.currency.queries.get_currencies_list.get_currencies_list_query import GetCurrenciesListQuery
from src.application.currency.queries.get_currency_detail.get_currency_detail_query import GetCurrencyDetailQuery
from src.domain.value_objects import CurrencyId  # CurrencyId = int
from src.presentation.rest_api.apps.currency.serializers import (
    CreateCurrencyRequestSerializer,
    DetailCurrencyResponseSerializer,
    ListCurrencyResponseSerializer,
    UpdateCurrencyRequestSerializer,
)
from src.presentation.rest_api.apps.common.base_api_view import BaseAPIView


class CurrencyAPIView(BaseAPIView[
    ListCurrencyResponseSerializer,
    DetailCurrencyResponseSerializer,
    CreateCurrencyRequestSerializer,
    UpdateCurrencyRequestSerializer,
    GetCurrenciesListQuery,
    GetCurrencyDetailQuery,
    AddCurrencyCommand,
    EditCurrencyCommand,
    RemoveCurrencyCommand,
    CurrencyId,  # PKType
]):
    authentication_classes = ()
    list_serializer = ListCurrencyResponseSerializer
    detail_serializer = DetailCurrencyResponseSerializer
    create_serializer = CreateCurrencyRequestSerializer
    update_serializer = UpdateCurrencyRequestSerializer
    list_query = GetCurrenciesListQuery
    detail_query = GetCurrencyDetailQuery
    create_command = AddCurrencyCommand
    update_command = EditCurrencyCommand
    remove_command = RemoveCurrencyCommand
    pk_type = CurrencyId  # CurrencyId = int
```

**Benefits:**

- **Simplified CRUD Creation:** By inheriting from `BaseAPIView` and specifying the required serializers, queries, commands, and `pk_type`, you can rapidly set up new CRUD endpoints without repetitive code.

- **Automatic Documentation:** The `ExtendSchemaMeta` metaclass ensures that all CRUD methods are properly documented in OpenAPI, reducing the need for manual documentation updates.

- **Enhanced Maintainability:** Centralizing common functionalities in `BaseAPIView` and using a metaclass for schema extensions makes the codebase easier to maintain and extend.

---

**Summary:**

This Pull Request enhances the API development workflow by introducing a reusable `BaseAPIView` and an `ExtendSchemaMeta` metaclass. These additions streamline the creation of CRUD endpoints, ensure consistent OpenAPI documentation, and improve overall code maintainability.
